### PR TITLE
Make entity parsing conform to XML standard

### DIFF
--- a/src/xml.grammar
+++ b/src/xml.grammar
@@ -84,9 +84,10 @@ Cdata { cdataStart cdataContent* "]]>" }
 
   Is { "=" }
 
-  EntityReference { "&" ![#; ]+ ";" }
+   // See https://www.w3.org/TR/2006/REC-xml11-20060816/#sec-references
+   EntityReference { "&" identifier ";" }
 
-  CharacterReference { "&#" ![; ]+ ";" }
+  CharacterReference { ("&#x" $[0-9a-fA-F]+ ";" | "&#" $[0-9]+ ";") }
 
   Text { ![<&]+ }
 

--- a/test/test-xml.js
+++ b/test/test-xml.js
@@ -1,5 +1,5 @@
 import {parser} from "../dist/index.js"
-import {fileTests} from "@lezer/generator/dist/test"
+import {fileTests, testTree} from "@lezer/generator/dist/test"
 
 import * as fs from "fs"
 import * as path from "path"
@@ -12,5 +12,9 @@ for (let file of fs.readdirSync(caseDir)) {
   describe(name, () => {
     for (let {name, run} of fileTests(fs.readFileSync(path.join(caseDir, file), "utf8"), file))
       it(name, () => run(parser))
+  })
+  it("InvalidEntities", () => {
+    testTree(parser.parse("&"), "Document(⚠)")
+    testTree(parser.parse("&amp&;"), "Document(⚠,Text,⚠,Text)")
   })
 }


### PR DESCRIPTION
The XML specification says entity references must have a valid identifier as their name. This PR adjusts the grammar to match the specification. The grammar will now produce parse errors when invalidly-named entities are used.