### PR TITLE
Added support for apostrophe or single-quote attribute values

### DIFF
--- a/src/xml.grammar
+++ b/src/xml.grammar
@@ -37,7 +37,10 @@ Attribute {
   AttributeName space* Is space* AttributeValue
 }
 
-AttributeValue[isolate] { "\"" (attributeContent | EntityReference | CharacterReference)* "\"" }
+AttributeValue[isolate] {
+  "\"" (attributeContentDouble | EntityReference | CharacterReference)* "\"" |
+  "\'" (attributeContentSingle | EntityReference | CharacterReference)* "\'"
+}
 
 Comment[isolate] { "<!--" commentContent* "-->" }
 
@@ -80,7 +83,9 @@ Cdata { cdataStart cdataContent* "]]>" }
 
   AttributeName { identifier }
 
-  attributeContent { !["&]+ }
+  attributeContentDouble { !["&]+ }
+
+  attributeContentSingle { !['&]+ }
 
   Is { "=" }
 

--- a/test/tags.txt
+++ b/test/tags.txt
@@ -25,7 +25,7 @@ Document(Element(OpenTag(StartTag,TagName,EndTag),
   Element(SelfClosingTag(StartTag,TagName,SelfCloseEndTag)),
 CloseTag(StartCloseTag,TagName,EndTag)))
 
-# Attribute
+# Attribute (double-quote)
 
 <a foo="bar"/>
 
@@ -33,13 +33,23 @@ CloseTag(StartCloseTag,TagName,EndTag)))
 
 Document(Element(SelfClosingTag(StartTag,TagName,Attribute(AttributeName,Is,AttributeValue),SelfCloseEndTag)))
 
-# Multiple attributes
+# Attribute (apostrophe or single-quote)
 
-<a x="one" y="two" z="three"></a>
+<a foo='bar'/>
+
+==>
+
+Document(Element(SelfClosingTag(StartTag,TagName,Attribute(AttributeName,Is,AttributeValue),SelfCloseEndTag)))
+
+
+# Multiple attributes (mixed quotes)
+
+<a b="one" c='two' d="three" e='four' ></a>
 
 ==>
 
 Document(Element(OpenTag(StartTag,TagName,
+  Attribute(AttributeName,Is,AttributeValue),
   Attribute(AttributeName,Is,AttributeValue),
   Attribute(AttributeName,Is,AttributeValue),
   Attribute(AttributeName,Is,AttributeValue),EndTag),


### PR DESCRIPTION
According to the XML syntax, single-quotes are also supported. (Source: https://www.w3.org/TR/xml/#syntax)

I added this support and some test, just like [the html-language](https://github.com/lezer-parser/html/commit/10c074bed1238a3b89f9575f66baccbc1b2cf159)